### PR TITLE
Use modern Qt5 fork

### DIFF
--- a/mm3d.spec
+++ b/mm3d.spec
@@ -9,8 +9,9 @@ Release:	1
 Epoch:		0
 License:	GPL
 Group:		X11/Graphics
-Source0:	http://dl.sourceforge.net/misfitmodel3d/%{name}-%{version}.tar.gz
+# Source0:	http://dl.sourceforge.net/misfitmodel3d/%{name}-%{version}.tar.gz
 # Source0-md5:	920363c114f8dcb1229ba5c90ec646fa
+Source0:	https://github.com/zturtleman/mm3d/archive/master.zip
 URL:		http://www.misfitcode.com/misfitmodel3d/
 BuildRequires:	lua50-devel
 BuildRequires:	qt-devel >= 6:3.3.3-4


### PR DESCRIPTION
The original version has not been maintained since 2009. I'm not sure how using a zip will affect your spec files, but that is the format available.

https://github.com/zturtleman/mm3d is a fork that has many, many new commits. It also converted from SVN instead of a tarball, so it has the old commits from 2009 and earlier. Retaining commit history can assist with crediting contributor(s), bisecting issues, and looking at reasons for commits to identify past issues for developing a regression test list. Maverick Model 3D (the name of the fork) seems to be maintained well, even recently.